### PR TITLE
Update due date for runs

### DIFF
--- a/_editions/2020/tasks/music.md
+++ b/_editions/2020/tasks/music.md
@@ -76,7 +76,7 @@ Minz Won, Music Technology Group, Universitat Pompeu Fabra, Spain
 
 #### Task Schedule
 * 13 July: Data release <!-- # Replace XX with your date. Latest possible is 31 July-->
-* 31 October: Runs due <!-- # Replace XX with your date. Latest possible is 31 October-->
+* 6 November: Runs due <!-- # Replace XX with your date. Latest possible is 31 October-->
 * 15 November: Results returned  <!-- Fixed. Please do not change-->
 * 30 November: Working notes paper  <!-- Fixed. Please do not change-->
 * Early December: MediaEval 2020 Workshop <!-- Fixed. Please do not change-->


### PR DESCRIPTION
We don't need as much time to return results to participants, so give them another week to submit